### PR TITLE
PR for user-set welcome channel

### DIFF
--- a/commands/welcome.js
+++ b/commands/welcome.js
@@ -1,0 +1,6 @@
+exports.run = (client, message, args) => {
+  if(!message.member.hasPermission('MANAGE_GUILD')) return message.reply('You don't have the permissions required to access this command!');
+  if(!message.mentions.channels.first) return message.reply('Please mention a channel! (Usage: [Prefix]welcome [#channel])');
+  client.guildMemberEnmap.set(message.guild.id, message.mentions.channels.first.id);
+  message.reply('Successfully set the welcome channel!');
+}

--- a/index.js
+++ b/index.js
@@ -39,6 +39,11 @@ const Enmap = require('enmap');
 const Provider = require('enmap-sqlite');
 const settings = new Enmap({ provider: new Provider({ name: "settings" }) }); // settings = welcomeMsg
 
+// guildMemberAdd Message Enmap
+// NOTE: In order for the enmap to be persistant (save on bot shutdown) you need the npm module "better-sqlite-pool"
+const guildMembrAdd = new Enmap({name: "guildMemberAdd"});
+client.guildMemberEnmap = guildMembrAdd;
+
 const defaultSettings = {
     welcome: true
 }

--- a/index.js
+++ b/index.js
@@ -137,6 +137,12 @@ client.on('guildDelete', async (guild) => {
 });
 
 client.on('guildMemberAdd', async member => {
+    // This information still needs to be filled in, so please look through ~Eton
+    if(!client.guildMemberEnmap.get(member.guild.id)) return console.log('No Enmap Settings Found');
+    client.guilds.find(t => t.id == member.guild.id).channels.find(t => t.id == client.guildMemberEnmap.get(member.guild.id)).send(WelcomeMessage);
+    
+    
+    // I'm not quite sure if this code is used for something else so I've left it here ~Eton
     let guild = member.guild; //= settings.getProp(guild.id, "welcome");
     let welcomeMessages;
     try {


### PR DESCRIPTION
There is still some things you need to edit, so please make sure to read the comments I've left!

**What I've done**
- Create Welcome Channel ID Enmap
- Add Code to guildMemberAdd event to use said enmap.
- Added commands/welcome.js to allow guild managers to set the welcome channel.